### PR TITLE
Fixing duplicate file items in the Clover report.  Fixing compiler warni...

### DIFF
--- a/src/VisualCoverage.Core/CloverReport.cs
+++ b/src/VisualCoverage.Core/CloverReport.cs
@@ -38,7 +38,7 @@ namespace VisualCoverage.Core
             
         }
         
-        public String Execute ( ProjectElement project ) {
+        public virtual String Execute ( ProjectElement project ) {
             
             StringBuilder buffer = new StringBuilder();
             

--- a/src/VisualCoverage.Core/HtmlReport.cs
+++ b/src/VisualCoverage.Core/HtmlReport.cs
@@ -42,7 +42,7 @@ namespace VisualCoverage.Core
             
         }
         
-        public String Execute ( ProjectElement project )
+        public override String Execute ( ProjectElement project )
         {
             // load our transform file out of the embedded resources
             Stream xsltStream = Assembly.GetExecutingAssembly().GetManifestResourceStream(

--- a/src/VisualCoverage.Core/MikeParser.cs
+++ b/src/VisualCoverage.Core/MikeParser.cs
@@ -135,7 +135,7 @@ namespace VisualCoverage.Core.Util
                     // Since it's one class per file (at least) declare
                     // file here and add it to the class.
                     uint fileid = 0;
-                    uint classlocs = 0;
+                    // uint classlocs = 0;
                     uint covered_methods = 0;
                     FileElement fe = null;
                     
@@ -187,11 +187,18 @@ namespace VisualCoverage.Core.Util
                     
                     if (fe != null)
                     {
-                        fe.AddClass(ce);
+                        if (!fe.GetClasses().Contains(ce))
+                        {
+                            fe.AddClass(ce);
+                        }
+
                         if (packages.ContainsKey((string)iclass["NamespaceKeyName"]))
                         {
                             PackageElement pe = packages[(string)iclass["NamespaceKeyName"]];
-                            pe.AddFile(fe);
+                            if (!pe.GetFiles().Contains(fe))
+                            {
+                                pe.AddFile(fe);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Fixed an issue where duplicate file items were appearing in the Clover XML report. Fixed compiler warnings.
