### PR TITLE
Fix for big clover files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Usage
 
 VisualCoverage.exe -i file.coverage [--html report.html] [--clover report.xml] 
     [--include-namespace pattern] [--exclude-namespace pattern]
-    [--include-file pattern] [--exclude-file pattern]
+    [--include-file pattern] [--exclude-file pattern] [--shortReport]
 
 Options:
 
@@ -36,6 +36,10 @@ Options:
 
   -i, --input           Required. Visual studio coverage (*.coverage) input
                         file. Can be specified multiple times.
+                        
+  -s, --shortReport     Create a short xml report and skip all detail information
+                        This means skipping class and line information, in order
+                        to create a report based on files.
 
   --include-namespace   Includes a namespace in the report. If no namespace is
                         added, all namespaces are included. This value can be
@@ -72,6 +76,9 @@ Examples
 
     # Generates a clover report from the coverage file
     VisualCoverage.exe --input somefile.coverage --clover clover.xml
+
+    # Generates a clover report from the coverage file without class and line information 
+    VisualCoverage.exe --input somefile.coverage --clover clover.xml --shortReport
 
     # Generates both reports from a single input file
     VisualCoverage.exe --input otherfile.coverage --html report.html --clover clover.xml

--- a/src/VisualCoverage.Console/CmdDriver.cs
+++ b/src/VisualCoverage.Console/CmdDriver.cs
@@ -112,6 +112,10 @@ namespace VisualCoverage.Console
                 }
             }
 
+            [Option("s", "shortReport", Required = false, DefaultValue = false, HelpText = "create only a short report (excluding line details)")]
+            public bool shortReport { get; set; }
+            // <---- end
+            
             [HelpOption]
             public string GetUsage()
             {
@@ -159,7 +163,7 @@ namespace VisualCoverage.Console
                 CloverReport cloverreport = new CloverReport();
                 using (StreamWriter outfile = new StreamWriter(options.CloverOutput))
                 {
-                    outfile.Write(cloverreport.Execute(pe));
+                    cloverreport.DirectWrite(outfile, pe, options.shortReport);
                 }
             }
             // Generate html report

--- a/src/VisualCoverage.Console/CmdDriver.cs
+++ b/src/VisualCoverage.Console/CmdDriver.cs
@@ -28,6 +28,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 //
+
+// ------------------------------------------------------------------------------------------------
+// (C) Siemens AG, 2018
+// a small change was done to deliver the name of the binary that was read.
+// a small change was done to catch an exception in some places where illegal path names were given.
+// Direct xml writing instead of string creator due to large xml files
+// added a command line switch /short to skip detail information on coverage.
+// ------------------------------------------------------------------------------------------------
 namespace VisualCoverage.Console
 {
     using System;
@@ -112,6 +120,7 @@ namespace VisualCoverage.Console
                 }
             }
 
+            // (C) Siemens AG, [2018] begin---> 
             [Option("s", "shortReport", Required = false, DefaultValue = false, HelpText = "create only a short report (excluding line details)")]
             public bool shortReport { get; set; }
             // <---- end
@@ -163,7 +172,10 @@ namespace VisualCoverage.Console
                 CloverReport cloverreport = new CloverReport();
                 using (StreamWriter outfile = new StreamWriter(options.CloverOutput))
                 {
+                    // (C) Siemens AG, [2018] begin---> 
                     cloverreport.DirectWrite(outfile, pe, options.shortReport);
+                    // outfile.Write(cloverreport.Execute(pe));
+                    // <---- end
                 }
             }
             // Generate html report

--- a/src/VisualCoverage.Console/CmdDriver.cs
+++ b/src/VisualCoverage.Console/CmdDriver.cs
@@ -29,13 +29,6 @@
 // THE SOFTWARE.
 //
 
-// ------------------------------------------------------------------------------------------------
-// (C) Siemens AG, 2018
-// a small change was done to deliver the name of the binary that was read.
-// a small change was done to catch an exception in some places where illegal path names were given.
-// Direct xml writing instead of string creator due to large xml files
-// added a command line switch /short to skip detail information on coverage.
-// ------------------------------------------------------------------------------------------------
 namespace VisualCoverage.Console
 {
     using System;
@@ -120,10 +113,8 @@ namespace VisualCoverage.Console
                 }
             }
 
-            // (C) Siemens AG, [2018] begin---> 
             [Option("s", "shortReport", Required = false, DefaultValue = false, HelpText = "create only a short report (excluding line details)")]
             public bool shortReport { get; set; }
-            // <---- end
             
             [HelpOption]
             public string GetUsage()
@@ -172,10 +163,7 @@ namespace VisualCoverage.Console
                 CloverReport cloverreport = new CloverReport();
                 using (StreamWriter outfile = new StreamWriter(options.CloverOutput))
                 {
-                    // (C) Siemens AG, [2018] begin---> 
                     cloverreport.DirectWrite(outfile, pe, options.shortReport);
-                    // outfile.Write(cloverreport.Execute(pe));
-                    // <---- end
                 }
             }
             // Generate html report

--- a/src/VisualCoverage.Core/CloverReport.cs
+++ b/src/VisualCoverage.Core/CloverReport.cs
@@ -26,11 +26,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 //
+
+// ------------------------------------------------------------------------------------------------
+// (C) Siemens AG, 2017
+// a small change was done to deliver the name of the binary that was read.
+// a small change was done to catch an exception in some places where illegal path names were given.
+// ------------------------------------------------------------------------------------------------
 namespace VisualCoverage.Core
 {
     using System;
     using System.Text;
+    // (C) Siemens AG, [2018] begin---> 
     using System.IO;
+    // <---- end
     using VisualCoverage.Core.Elements;
 
     public class CloverReport
@@ -39,6 +47,7 @@ namespace VisualCoverage.Core
             
         }
         
+        // (C) Siemens AG, [2018] begin---> 
         public void DirectWrite(StreamWriter outfile, ProjectElement project, bool shortReport)
         {
             outfile.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
@@ -81,6 +90,7 @@ namespace VisualCoverage.Core
             outfile.Write("</project>");
             outfile.Write("</coverage>");
         }
+        // <---- end
 
         public virtual String Execute ( ProjectElement project ) {
             

--- a/src/VisualCoverage.Core/CloverReport.cs
+++ b/src/VisualCoverage.Core/CloverReport.cs
@@ -27,18 +27,11 @@
 // THE SOFTWARE.
 //
 
-// ------------------------------------------------------------------------------------------------
-// (C) Siemens AG, 2017
-// a small change was done to deliver the name of the binary that was read.
-// a small change was done to catch an exception in some places where illegal path names were given.
-// ------------------------------------------------------------------------------------------------
 namespace VisualCoverage.Core
 {
     using System;
     using System.Text;
-    // (C) Siemens AG, [2018] begin---> 
     using System.IO;
-    // <---- end
     using VisualCoverage.Core.Elements;
 
     public class CloverReport
@@ -47,7 +40,6 @@ namespace VisualCoverage.Core
             
         }
         
-        // (C) Siemens AG, [2018] begin---> 
         public void DirectWrite(StreamWriter outfile, ProjectElement project, bool shortReport)
         {
             outfile.Write("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>");
@@ -90,7 +82,6 @@ namespace VisualCoverage.Core
             outfile.Write("</project>");
             outfile.Write("</coverage>");
         }
-        // <---- end
 
         public virtual String Execute ( ProjectElement project ) {
             

--- a/src/VisualCoverage.Core/MikeParser.cs
+++ b/src/VisualCoverage.Core/MikeParser.cs
@@ -27,11 +27,6 @@
 // THE SOFTWARE.
 //
 
-// ------------------------------------------------------------------------------------------------
-// (C) Siemens AG, 2017
-// a small change was done to deliver the name of the binary that was read.
-// a small change was done to catch an exception in some places where illegal path names were given.
-// ------------------------------------------------------------------------------------------------
 namespace VisualCoverage.Core.Util
 {
     using System;
@@ -219,10 +214,7 @@ namespace VisualCoverage.Core.Util
                     __includeNamespaces.Add(".*");
                 // Check if the namespace is included
 
-                // (C) Siemens AG, [2017] begin---> 
-                // String nsname = (string)row["NamespaceName"];
                 String nsname = (string)row.ItemArray[5];
-                // <---- end
                 foreach (string entry in __includeNamespaces)
                 {
                     if (TestRegex(nsname, entry)) 
@@ -282,10 +274,6 @@ namespace VisualCoverage.Core.Util
                 // add it to the dictionary
                 if (include)
                 {
-                    // (C) Siemens AG, [2017] begin---> 
-                    // FileInfo info = new FileInfo(fname);
-                    // FileElement fe = new FileElement (info.Name, info.FullName);
-                    // dest.Add((uint)row["SourceFileID"], fe);
                     try
                     {
                         FileInfo info = new FileInfo(fname);

--- a/src/VisualCoverage.Core/MikeParser.cs
+++ b/src/VisualCoverage.Core/MikeParser.cs
@@ -212,7 +212,9 @@ namespace VisualCoverage.Core.Util
                 if (__includeNamespaces.Count < 1)
                     __includeNamespaces.Add(".*");
                 // Check if the namespace is included
-                String nsname = (string)row["NamespaceName"];
+                // String nsname = (string)row["NamespaceName"];
+                String nsname = (string)row.ItemArray[5];
+                
                 foreach (string entry in __includeNamespaces)
                 {
                     if (TestRegex(nsname, entry)) 
@@ -272,9 +274,16 @@ namespace VisualCoverage.Core.Util
                 // add it to the dictionary
                 if (include)
                 {
-                    FileInfo info = new FileInfo(fname);
-                    FileElement fe = new FileElement (info.Name, info.FullName);
-                    dest.Add((uint)row["SourceFileID"], fe);
+                    try
+                    {
+                        FileInfo info = new FileInfo(fname);
+                        FileElement fe = new FileElement(info.Name, info.FullName);
+                        dest.Add((uint)row["SourceFileID"], fe);
+                    }
+                    catch (Exception e)
+                    {
+                        Console.WriteLine("Error reading file {0}. Message = {1}", fname, e.Message);
+                    }
                 }
             }
         }

--- a/src/VisualCoverage.Core/MikeParser.cs
+++ b/src/VisualCoverage.Core/MikeParser.cs
@@ -26,6 +26,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 //
+
+// ------------------------------------------------------------------------------------------------
+// (C) Siemens AG, 2017
+// a small change was done to deliver the name of the binary that was read.
+// a small change was done to catch an exception in some places where illegal path names were given.
+// ------------------------------------------------------------------------------------------------
 namespace VisualCoverage.Core.Util
 {
     using System;
@@ -212,9 +218,11 @@ namespace VisualCoverage.Core.Util
                 if (__includeNamespaces.Count < 1)
                     __includeNamespaces.Add(".*");
                 // Check if the namespace is included
+
+                // (C) Siemens AG, [2017] begin---> 
                 // String nsname = (string)row["NamespaceName"];
                 String nsname = (string)row.ItemArray[5];
-                
+                // <---- end
                 foreach (string entry in __includeNamespaces)
                 {
                     if (TestRegex(nsname, entry)) 
@@ -274,6 +282,10 @@ namespace VisualCoverage.Core.Util
                 // add it to the dictionary
                 if (include)
                 {
+                    // (C) Siemens AG, [2017] begin---> 
+                    // FileInfo info = new FileInfo(fname);
+                    // FileElement fe = new FileElement (info.Name, info.FullName);
+                    // dest.Add((uint)row["SourceFileID"], fe);
                     try
                     {
                         FileInfo info = new FileInfo(fname);
@@ -284,6 +296,7 @@ namespace VisualCoverage.Core.Util
                     {
                         Console.WriteLine("Error reading file {0}. Message = {1}", fname, e.Message);
                     }
+                    // <---- end
                 }
             }
         }


### PR DESCRIPTION
Hi,
This pull request is for fixing the following issue:

1. If the MSVS coverage file gets huge, and therefore the xml output gets also huge (>>200 MB), visual coverage crashes due to memory restrictions (2 GB RAM). Pushing all XML tags into string builder and then create the xml on the fly consumes too much memory.
I enhanced the XML creation (if not used as base for HTML) to directly write to the file. This solves the problem and makes the program run faster.
2. If the inspected binaries contain COM references, there were crashes due to file names that might not exist on the HD (the file paths were no real windows file paths in this case). This is now checked and if invalid, thrown away.
3. I added an option to create a "short" report, which means, that detailed information is skipped from the xml file (e.g. class and line statistics). This was necessary, as we keep our raw data which we use to create reports, for a longer time. If there are 20 files with each 250 MB per report, this gets a huge memory consumption. If the CL switch --shortReport is added, detailed information is skipped and the XML files get a lot smaller.
